### PR TITLE
fix - `Hash#to_struct` exception for empty hashes on Ruby 3.2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736883708,
-        "narHash": "sha256-uQ+NQ0/xYU0N1CnXsa2zghgNaOPxWpMJXSUJJ9W7140=",
+        "lastModified": 1742422364,
+        "narHash": "sha256-mNqIplmEohk5jRkqYqG19GA8MbQ/D4gQSK0Mu4LvfRQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+        "rev": "a84ebe20c6bc2ecbcfb000a50776219f48d134cc",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,8 +6,14 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
       in

--- a/lib/everythingrb/core/hash.rb
+++ b/lib/everythingrb/core/hash.rb
@@ -17,6 +17,19 @@
 #
 class Hash
   #
+  # A minimal empty struct for Ruby 3.2+ compatibility
+  #
+  # Ruby 3.2 enforces stricter argument handling for Struct. This means trying to create
+  # a Struct from an empty Hash will result in an ArgumentError being raised.
+  # This is trying to keep a consistent experience with that version and newer versions.
+  #
+  # @return [Struct] A struct with a single nil-valued field
+  #
+  # @api private
+  #
+  EMPTY_STRUCT = Struct.new(:_).new(nil)
+
+  #
   # Combines filter_map and join operations
   #
   # @param join_with [String] The delimiter to join elements with (defaults to empty string)
@@ -79,6 +92,9 @@ class Hash
   #   struct.class # => Struct
   #
   def to_struct
+    # For Ruby 3.2, it raises if you attempt to create a Struct with no keys
+    return EMPTY_STRUCT if RUBY_VERSION.start_with?("3.2") && empty?
+
     recurse = lambda do |value|
       case value
       when Hash

--- a/test/core/hash/test_to_struct.rb
+++ b/test/core/hash/test_to_struct.rb
@@ -62,4 +62,10 @@ class TestHashToStruct < Minitest::Test
     assert_kind_of(Struct, second)
     assert_equal(2, second.d)
   end
+
+  def test_it_handles_empty
+    output = {}.to_struct
+
+    assert_kind_of(Struct, output)
+  end
 end


### PR DESCRIPTION
This PR fixes a bug for Ruby 3.2 only. This can be reproduced by calling `#to_struct` on an empty hash