### PR TITLE
feat - Added array trimming methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [0.2.5] - 12025-03-29
+
+### Added
+
+- New array trimming methods that preserve internal structure:
+  - `compact_prefix` - Removes nil values from the beginning of an array
+  - `compact_suffix` - Removes nil values from the end of an array
+  - `trim_nils` - Removes nil values from both ends of an array
+  - ActiveSupport integration with blank-aware versions:
+    - `compact_blank_prefix` - Removes blank values from the beginning
+    - `compact_blank_suffix` - Removes blank values from the end
+    - `trim_blanks` - Removes blank values from both ends
+
 ## [0.2.4] - 12025-03-20
 
 ### Changed
@@ -111,8 +124,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added alias `each` to `each_pair` in OpenStruct for better enumerable compatibility
 
-[unreleased]: https://github.com/itsthedevman/everythingrb/compare/v0.2.4...HEAD
-[0.2.3]: https://github.com/itsthedevman/everythingrb/compare/v0.2.3...v0.2.4
+[unreleased]: https://github.com/itsthedevman/everythingrb/compare/v0.2.5...HEAD
+[0.2.5]: https://github.com/itsthedevman/everythingrb/compare/v0.2.4...v0.2.5
+[0.2.4]: https://github.com/itsthedevman/everythingrb/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/itsthedevman/everythingrb/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/itsthedevman/everythingrb/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/itsthedevman/everythingrb/compare/v0.2.0...v0.2.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    everythingrb (0.2.4)
+    everythingrb (0.2.5)
       json (~> 2.9)
       ostruct (~> 0.6)
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ I'm currently looking for opportunities where I can tackle meaningful problems a
   - [Collection Processing](#collection-processing)
   - [JSON & String Handling](#json--string-handling)
   - [Object Freezing](#object-freezing)
+  - [Array Trimming](#array-trimming)
   - [Predicate Methods](#predicate-methods)
 - [Core Extensions](#core-extensions)
   - [Array](#array)
@@ -138,6 +139,22 @@ config[:api][:endpoints].frozen?  # => true
 config[:api][:endpoints][0].frozen?  # => true
 ```
 
+### Array Trimming
+
+Clean up array boundaries without losing internal structure:
+
+```ruby
+# Remove nil values from the beginning or end
+[nil, nil, 1, nil, 2, nil, nil].trim_nils  # => [1, nil, 2]
+
+# With ActiveSupport, remove any blank values (nil, "", etc.)
+[nil, "", 1, "", 2, nil, ""].trim_blanks  # => [1, "", 2]
+
+# Only trim from one end if needed
+[nil, nil, 1, 2, 3].compact_prefix  # => [1, 2, 3]
+[1, 2, 3, nil, nil].compact_suffix  # => [1, 2, 3]
+```
+
 ### Predicate Methods
 
 Create boolean accessors with minimal code:
@@ -226,6 +243,34 @@ data = [
 
 data.dig_map(:user, :profile, :name)
 # => ["Alice", "Bob"]
+```
+
+#### `compact_prefix` / `compact_suffix` / `trim_nils`
+Remove nil values from the beginning, end, or both ends of an array without touching interior nil values.
+
+```ruby
+[nil, nil, 1, nil, 2, nil, nil].compact_prefix
+# => [1, nil, 2, nil, nil]
+
+[1, nil, 2, nil, nil].compact_suffix
+# => [1, nil, 2]
+
+[nil, nil, 1, nil, 2, nil, nil].trim_nils
+# => [1, nil, 2]
+```
+
+#### `compact_blank_prefix` / `compact_blank_suffix` / `trim_blanks` (with ActiveSupport)
+Remove blank values (nil, empty strings, etc.) from the beginning, end, or both ends of an array.
+
+```ruby
+[nil, "", 1, "", 2, nil, ""].compact_blank_prefix
+# => [1, "", 2, nil, ""]
+
+[nil, "", 1, "", 2, nil, ""].compact_blank_suffix
+# => [nil, "", 1, "", 2]
+
+[nil, "", 1, "", 2, nil, ""].trim_blanks
+# => [1, "", 2]
 ```
 
 #### `deep_freeze`

--- a/lib/everythingrb/core/array.rb
+++ b/lib/everythingrb/core/array.rb
@@ -97,4 +97,85 @@ class Array
     each { |v| v.respond_to?(:deep_freeze) ? v.deep_freeze : v.freeze }
     freeze
   end
+
+  #
+  # Removes nil values from the beginning of an array
+  #
+  # @return [Array] Array with leading nil values removed
+  #
+  # @example
+  #   [nil, nil, 1, 2, nil, 3].compact_prefix
+  #   # => [1, 2, nil, 3]
+  #
+  def compact_prefix
+    drop_while(&:nil?)
+  end
+
+  #
+  # Removes nil values from the end of an array
+  #
+  # @return [Array] Array with trailing nil values removed
+  #
+  # @example
+  #   [1, 2, nil, 3, nil, nil].compact_suffix
+  #   # => [1, 2, nil, 3]
+  #
+  def compact_suffix
+    reverse.drop_while(&:nil?).reverse
+  end
+
+  #
+  # Removes nil values from both the beginning and end of an array
+  #
+  # @return [Array] Array with leading and trailing nil values removed
+  #
+  # @example
+  #   [nil, nil, 1, 2, nil, 3, nil, nil].trim_nils
+  #   # => [1, 2, nil, 3]
+  #
+  def trim_nils
+    compact_prefix.compact_suffix
+  end
+
+  # ActiveSupport integrations
+  if defined?(ActiveSupport)
+    #
+    # Removes blank values from the beginning of an array
+    #
+    # @return [Array] Array with leading blank values removed
+    #
+    # @example With ActiveSupport loaded
+    #   [nil, "", 1, 2, "", 3].compact_blank_prefix
+    #   # => [1, 2, "", 3]
+    #
+    def compact_blank_prefix
+      drop_while(&:blank?)
+    end
+
+    #
+    # Removes blank values from the end of an array
+    #
+    # @return [Array] Array with trailing blank values removed
+    #
+    # @example With ActiveSupport loaded
+    #   [1, 2, "", 3, nil, ""].compact_blank_suffix
+    #   # => [1, 2, "", 3]
+    #
+    def compact_blank_suffix
+      reverse.drop_while(&:blank?).reverse
+    end
+
+    #
+    # Removes blank values from both the beginning and end of an array
+    #
+    # @return [Array] Array with leading and trailing blank values removed
+    #
+    # @example With ActiveSupport loaded
+    #   [nil, "", 1, 2, "", 3, nil, ""].trim_blanks
+    #   # => [1, 2, "", 3]
+    #
+    def trim_blanks
+      compact_blank_prefix.compact_blank_suffix
+    end
+  end
 end

--- a/lib/everythingrb/version.rb
+++ b/lib/everythingrb/version.rb
@@ -7,5 +7,5 @@
 #
 module Everythingrb
   # Current version of the everythingrb gem
-  VERSION = "0.2.4"
+  VERSION = "0.2.5"
 end

--- a/test/core/array/test_compact_blank_prefix_active_support.rb
+++ b/test/core/array/test_compact_blank_prefix_active_support.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestArrayCompactBlankPrefix < Minitest::Test
+  def test_it_removes_leading_blanks
+    result = [nil, "", "foo", 1, "", "bar", "", nil].compact_blank_prefix
+
+    # It does not remove trailing blank values
+    assert_equal(["foo", 1, "", "bar", "", nil], result)
+  end
+
+  def test_it_handles_empty_array
+    assert_equal([], [].compact_blank_prefix)
+  end
+
+  def test_it_handles_single_item_array
+    assert_equal([1], [1].compact_blank_prefix)
+  end
+
+  def test_it_handles_array_of_blanks
+    assert_equal([], [nil, "", nil].compact_blank_prefix)
+  end
+end

--- a/test/core/array/test_compact_blank_suffix_active_support.rb
+++ b/test/core/array/test_compact_blank_suffix_active_support.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestArrayCompactBlankSuffix < Minitest::Test
+  def test_it_removes_trailing_blanks
+    result = [nil, "", "foo", 1, "", "bar", "", nil].compact_blank_suffix
+
+    # It does not remove leading blank values
+    assert_equal([nil, "", "foo", 1, "", "bar"], result)
+  end
+
+  def test_it_handles_empty_array
+    assert_equal([], [].compact_blank_suffix)
+  end
+
+  def test_it_handles_single_item_array
+    assert_equal([1], [1].compact_blank_suffix)
+  end
+
+  def test_it_handles_array_of_blanks
+    assert_equal([], [nil, "", nil].compact_blank_suffix)
+  end
+end

--- a/test/core/array/test_compact_prefix.rb
+++ b/test/core/array/test_compact_prefix.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestArrayCompactPrefix < Minitest::Test
+  def test_it_removes_leading_nils
+    result = [nil, nil, "", nil, 1, nil, nil, nil].compact_prefix
+
+    # It does not remove trailing nils or blank values
+    assert_equal(["", nil, 1, nil, nil, nil], result)
+  end
+
+  def test_it_handles_empty_array
+    assert_equal([], [].compact_prefix)
+  end
+
+  def test_it_handles_single_item_array
+    assert_equal([1], [1].compact_prefix)
+  end
+
+  def test_it_handles_array_of_nils
+    assert_equal([], [nil, nil, nil].compact_prefix)
+  end
+end

--- a/test/core/array/test_compact_suffix.rb
+++ b/test/core/array/test_compact_suffix.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestArrayCompactSuffix < Minitest::Test
+  def test_it_removes_trailing_nils
+    result = [nil, nil, "", nil, 1, nil, nil, nil].compact_suffix
+
+    # It does not remove leading nils or blank values
+    assert_equal([nil, nil, "", nil, 1], result)
+  end
+
+  def test_it_handles_empty_array
+    assert_equal([], [].compact_suffix)
+  end
+
+  def test_it_handles_single_item_array
+    assert_equal([1], [1].compact_suffix)
+  end
+
+  def test_it_handles_array_of_nils
+    assert_equal([], [nil, nil, nil].compact_suffix)
+  end
+end

--- a/test/core/array/test_trim_blanks_active_support.rb
+++ b/test/core/array/test_trim_blanks_active_support.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestArrayTrimBlanks < Minitest::Test
+  def test_it_removes_leading_and_trailing_blanks
+    result = [nil, "", "foo", 1, "", "bar", "", nil].trim_blanks
+
+    # It does not remove inner blank values
+    assert_equal(["foo", 1, "", "bar"], result)
+  end
+
+  def test_it_handles_empty_array
+    assert_equal([], [].trim_blanks)
+  end
+
+  def test_it_handles_single_item_array
+    assert_equal([1], [1].trim_blanks)
+  end
+
+  def test_it_handles_array_of_blanks
+    assert_equal([], [nil, "", nil].trim_blanks)
+  end
+end

--- a/test/core/array/test_trim_nils.rb
+++ b/test/core/array/test_trim_nils.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestArrayTrimNils < Minitest::Test
+  def test_it_removes_leading_and_trailing_nils
+    result = [nil, nil, "", nil, 1, nil, nil, nil].trim_nils
+
+    # It does not remove blank values
+    assert_equal(["", nil, 1], result)
+  end
+
+  def test_it_handles_empty_array
+    assert_equal([], [].trim_nils)
+  end
+
+  def test_it_handles_single_item_array
+    assert_equal([1], [1].trim_nils)
+  end
+
+  def test_it_handles_array_of_nils
+    assert_equal([], [nil, nil, nil].compact_prefix)
+  end
+end


### PR DESCRIPTION
### Added

- New array trimming methods that preserve internal structure:
  - `compact_prefix` - Removes nil values from the beginning of an array
  - `compact_suffix` - Removes nil values from the end of an array
  - `trim_nils` - Removes nil values from both ends of an array
  - ActiveSupport integration with blank-aware versions:
    - `compact_blank_prefix` - Removes blank values from the beginning
    - `compact_blank_suffix` - Removes blank values from the end
    - `trim_blanks` - Removes blank values from both ends

