### PR TITLE
fix(core) - Fixed `Hash#value_where` crash when nothing is found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [0.3.1] - 12025-04-09
+
+### Added
+
+### Changed
+
+- Fixed `Hash#value_where` error when nothing is found
+
+### Removed
+
 ## [0.3.0] - 12025-04-09
 
 ### Added
@@ -139,7 +149,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added alias `each` to `each_pair` in OpenStruct for better enumerable compatibility
 
-[unreleased]: https://github.com/itsthedevman/everythingrb/compare/v0.3.0...HEAD
+[unreleased]: https://github.com/itsthedevman/everythingrb/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/itsthedevman/everythingrb/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/itsthedevman/everythingrb/compare/v0.2.5...v0.3.0
 [0.2.5]: https://github.com/itsthedevman/everythingrb/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/itsthedevman/everythingrb/compare/v0.2.3...v0.2.4

--- a/lib/everythingrb/core/hash.rb
+++ b/lib/everythingrb/core/hash.rb
@@ -310,7 +310,7 @@ class Hash
   def value_where(&block)
     return to_enum(:value_where) if block.nil?
 
-    find(&block).last
+    find(&block)&.last
   end
 
   #

--- a/test/core/hash/test_value_where.rb
+++ b/test/core/hash/test_value_where.rb
@@ -15,4 +15,8 @@ class TestHashValueWhere < Minitest::Test
       users.value_where { |k, v| v[:role] == "admin" }
     )
   end
+
+  def test_it_handles_if_it_finds_nothing
+    assert_nil(nil, {}.value_where { |k, v| k })
+  end
 end

--- a/test/core/hash/test_values_where.rb
+++ b/test/core/hash/test_values_where.rb
@@ -15,4 +15,8 @@ class TestHashValuesWhere < Minitest::Test
       users.values_where { |k, v| v[:role] == "admin" }
     )
   end
+
+  def test_it_handles_finding_nothing
+    assert_equal([], {}.values_where { |k, v| k })
+  end
 end


### PR DESCRIPTION
Closes #18 

This was just me being a silly and forgetting to handle `nil`. 