### PR TITLE
feat(core) - Add methods for renaming keys on Hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added new `Hash` methods for renaming keys:
+  - `#rename_key` - Renames a key in the hash while preserving the original order of elements
+  - `#rename_key!` - Same as `#rename_key` but modifies the hash in place
+  - `#rename_keys` - Renames multiple keys in the hash while preserving the original order of elements
+  - `#rename_keys!` - Same as `#rename_keys` but modifies the hash in place
+  - `#rename_key_unordered` - Renames a key without preserving element order (faster operation)
+  - `#rename_key_unordered!` - Same as `#rename_key_unordered` but modifies the hash in place
+
 ### Changed
 
 ### Removed
@@ -74,7 +82,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `Symbol#with_quotes` and `Symbol#in_quotes`
 
-
 ## [0.2.2] - 12025-03-03
 
 ### Added
@@ -93,7 +100,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Removed `Data` definition check for `to_istruct`
-
 
 ## [0.2.0] - 12025-02-17
 
@@ -118,7 +124,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Separated out tests that require `ActiveSupport` into their own test process. Files that end with `_active_support` will be tested separately with ActiveSupport loaded
-
 
 ## [0.1.1] - 12025-02-07
 

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,9 @@ gem "standard", "~> 1.3"
 
 gem "activesupport", "~> 8.0"
 
+gem "irb"
 gem "pry"
+gem "benchmark-ips"
 
 group :development, :documentation do
   gem "yard"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,7 @@ GEM
     ast (2.4.2)
     base64 (0.2.0)
     benchmark (0.4.0)
+    benchmark-ips (2.14.0)
     bigdecimal (3.1.9)
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
@@ -32,6 +33,11 @@ GEM
     drb (2.2.1)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    io-console (0.8.0)
+    irb (1.15.2)
+      pp (>= 0.6.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.10.1)
     kramdown (2.5.1)
       rexml (>= 3.3.9)
@@ -45,6 +51,9 @@ GEM
     parser (3.3.7.1)
       ast (~> 2.4.1)
       racc
+    pp (0.6.2)
+      prettyprint
+    prettyprint (0.2.0)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -57,6 +66,8 @@ GEM
     rdoc (6.13.1)
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
+    reline (0.6.1)
+      io-console (~> 0.5)
     rexml (3.4.1)
     rubocop (1.71.2)
       json (~> 2.3)
@@ -101,7 +112,9 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (~> 8.0)
+  benchmark-ips
   everythingrb!
+  irb
   kramdown
   minitest (~> 5.16)
   pry

--- a/lib/everythingrb/core/hash.rb
+++ b/lib/everythingrb/core/hash.rb
@@ -340,97 +340,97 @@ class Hash
   end
 
   #
-  # Replaces a key in the hash while preserving the original order of elements
+  # Renames a key in the hash while preserving the original order of elements
   #
-  # @param old_key [Object] The key to replace
+  # @param old_key [Object] The key to rename
   # @param new_key [Object] The new key to use
   #
-  # @return [Hash] A new hash with the key replaced
+  # @return [Hash] A new hash with the key renamed
   #
-  # @example Replace a single key
-  #   {a: 1, b: 2, c: 3}.replace_key(:b, :middle)
+  # @example Renames a single key
+  #   {a: 1, b: 2, c: 3}.rename_key(:b, :middle)
   #   # => {a: 1, middle: 2, c: 3}
   #
-  def replace_key(old_key, new_key)
-    replace_keys(old_key => new_key)
+  def rename_key(old_key, new_key)
+    rename_keys(old_key => new_key)
   end
 
   #
-  # Replaces a key in the hash in place while preserving the original order of elements
+  # Renames a key in the hash in place while preserving the original order of elements
   #
-  # @param old_key [Object] The key to replace
+  # @param old_key [Object] The key to rename
   # @param new_key [Object] The new key to use
   #
   # @return [self] The modified hash
   #
-  # @example Replace a key in place
+  # @example Renames a key in place
   #   hash = {a: 1, b: 2, c: 3}
-  #   hash.replace_key!(:b, :middle)
+  #   hash.rename_key!(:b, :middle)
   #   # => {a: 1, middle: 2, c: 3}
   #
-  def replace_key!(old_key, new_key)
-    replace_keys!(old_key => new_key)
+  def rename_key!(old_key, new_key)
+    rename_keys!(old_key => new_key)
   end
 
   #
-  # Replaces multiple keys in the hash while preserving the original order of elements
+  # Renames multiple keys in the hash while preserving the original order of elements
   #
-  # This method maintains the original order of all keys in the hash, replacing
+  # This method maintains the original order of all keys in the hash, renaming
   # only the specified keys while keeping their positions unchanged.
   #
   # @param keys [Hash] A mapping of old_key => new_key pairs
   #
-  # @return [Hash] A new hash with keys replaced
+  # @return [Hash] A new hash with keys renamed
   #
-  # @example Replace multiple keys
-  #   {a: 1, b: 2, c: 3, d: 4}.replace_keys(a: :first, c: :third)
+  # @example Renames multiple keys
+  #   {a: 1, b: 2, c: 3, d: 4}.rename_keys(a: :first, c: :third)
   #   # => {first: 1, b: 2, third: 3, d: 4}
   #
-  def replace_keys(**keys)
-    # I tried multiple different ways to replace the key while preserving the order, this was the fastest
+  def rename_keys(**keys)
+    # I tried multiple different ways to rename the key while preserving the order, this was the fastest
     transform_keys do |key|
       keys.key?(key) ? keys[key] : key
     end
   end
 
   #
-  # Replaces multiple keys in the hash in place while preserving the original order of elements
+  # Renames multiple keys in the hash in place while preserving the original order of elements
   #
-  # This method maintains the original order of all keys in the hash, replacing
+  # This method maintains the original order of all keys in the hash, renaming
   # only the specified keys while keeping their positions unchanged.
   #
   # @param keys [Hash] A mapping of old_key => new_key pairs
   #
   # @return [self] The modified hash
   #
-  # @example Replace multiple keys in place
+  # @example Rename multiple keys in place
   #   hash = {a: 1, b: 2, c: 3, d: 4}
-  #   hash.replace_keys!(a: :first, c: :third)
+  #   hash.rename_keys!(a: :first, c: :third)
   #   # => {first: 1, b: 2, third: 3, d: 4}
   #
-  def replace_keys!(**keys)
-    # I tried multiple different ways to replace the key while preserving the order, this was the fastest
+  def rename_keys!(**keys)
+    # I tried multiple different ways to rename the key while preserving the order, this was the fastest
     transform_keys! do |key|
       keys.key?(key) ? keys[key] : key
     end
   end
 
   #
-  # Replaces a key in the hash without preserving element order (faster)
+  # Renames a key in the hash without preserving element order (faster)
   #
-  # This method is significantly faster than #replace_key but does not
+  # This method is significantly faster than #rename_key but does not
   # guarantee that the order of elements in the hash will be preserved.
   #
-  # @param old_key [Object] The key to replace
+  # @param old_key [Object] The key to rename
   # @param new_key [Object] The new key to use
   #
-  # @return [Hash] A new hash with the key replaced
+  # @return [Hash] A new hash with the key renamed
   #
-  # @example Replace a single key without preserving order
-  #   {a: 1, b: 2, c: 3}.replace_key_unordered(:b, :middle)
+  # @example Rename a single key without preserving order
+  #   {a: 1, b: 2, c: 3}.rename_key_unordered(:b, :middle)
   #   # => {a: 1, c: 3, middle: 2}  # Order may differ
   #
-  def replace_key_unordered(old_key, new_key)
+  def rename_key_unordered(old_key, new_key)
     # Fun thing I learned. For small hashes, using #except is 1.5x faster than using dup and delete.
     # But as the hash becomes larger, the performance improvements become diminished until they're roughly the same.
     # Neat!
@@ -440,22 +440,22 @@ class Hash
   end
 
   #
-  # Replaces a key in the hash in place without preserving element order (faster)
+  # Renames a key in the hash in place without preserving element order (faster)
   #
-  # This method is significantly faster than #replace_key! but does not
+  # This method is significantly faster than #rename_key! but does not
   # guarantee that the order of elements in the hash will be preserved.
   #
-  # @param old_key [Object] The key to replace
+  # @param old_key [Object] The key to rename
   # @param new_key [Object] The new key to use
   #
   # @return [self] The modified hash
   #
-  # @example Replace a key in place without preserving order
+  # @example Rename a key in place without preserving order
   #   hash = {a: 1, b: 2, c: 3}
-  #   hash.replace_key_unordered!(:b, :middle)
+  #   hash.rename_key_unordered!(:b, :middle)
   #   # => {a: 1, c: 3, middle: 2}  # Order may differ
   #
-  def replace_key_unordered!(old_key, new_key)
+  def rename_key_unordered!(old_key, new_key)
     self[new_key] = delete(old_key)
     self
   end

--- a/lib/everythingrb/core/hash.rb
+++ b/lib/everythingrb/core/hash.rb
@@ -460,53 +460,6 @@ class Hash
     self
   end
 
-  #
-  # Replaces multiple keys in the hash without preserving element order (faster)
-  #
-  # This method is significantly faster than #replace_keys but does not
-  # guarantee that the order of elements in the hash will be preserved.
-  #
-  # @param keys [Hash] A mapping of old_key => new_key pairs
-  #
-  # @return [Hash] A new hash with keys replaced
-  #
-  # @example Replace multiple keys without preserving order
-  #   {a: 1, b: 2, c: 3, d: 4}.replace_keys_unordered(a: :first, c: :third)
-  #   # => {b: 2, d: 4, first: 1, third: 3}  # Order may differ
-  #
-  def replace_keys_unordered(**keys)
-    hash = except(*keys.keys)
-
-    keys.each do |old_key, new_key|
-      hash[new_key] = self[old_key]
-    end
-
-    hash
-  end
-
-  #
-  # Replaces multiple keys in the hash in place without preserving element order (faster)
-  #
-  # This method is significantly faster than #replace_keys! but does not
-  # guarantee that the order of elements in the hash will be preserved.
-  #
-  # @param keys [Hash] A mapping of old_key => new_key pairs
-  #
-  # @return [self] The modified hash
-  #
-  # @example Replace multiple keys in place without preserving order
-  #   hash = {a: 1, b: 2, c: 3, d: 4}
-  #   hash.replace_keys_unordered!(a: :first, c: :third)
-  #   # => {b: 2, d: 4, first: 1, third: 3}  # Order may differ
-  #
-  def replace_keys_unordered!(**keys)
-    keys.each do |old_key, new_key|
-      self[new_key] = delete(old_key)
-    end
-
-    self
-  end
-
   private
 
   def transform_values_enumerator

--- a/lib/everythingrb/core/hash.rb
+++ b/lib/everythingrb/core/hash.rb
@@ -339,6 +339,34 @@ class Hash
     select(&block).values
   end
 
+  def replace_key(old_key, new_key)
+    # Fun thing I learned. For small hashes, using #except is 1.5x faster than using dup and delete.
+    # But as the hash becomes larger, the performance improvements become diminished until they're roughly the same
+    # Neat!
+    hash = except(old_key)
+    hash[new_key] = self[old_key]
+    hash
+  end
+
+  def replace_key!(old_key, new_key)
+    self[new_key] = delete(old_key)
+    self
+  end
+
+  def replace_keys(**keys)
+    hash = except(*keys.keys)
+
+    keys.each do |old_key, new_key|
+      hash[new_key] = self[old_key]
+    end
+
+    hash
+  end
+
+  def replace_keys!(**keys)
+    self
+  end
+
   private
 
   def transform_values_enumerator

--- a/test/core/hash/test_replace_key.rb
+++ b/test/core/hash/test_replace_key.rb
@@ -3,18 +3,18 @@
 require "test_helper"
 
 class TestReplaceKey < Minitest::Test
-  def test_it_replaces_the_key
+  def test_it_renames_the_key
     hash = {key_1: 1, key_2: 2}
-    new_hash = hash.replace_key(:key_1, :key_one)
+    new_hash = hash.rename_key(:key_1, :key_one)
 
     refute_same(hash, new_hash)
     assert_equal({key_1: 1, key_2: 2}, hash)
     assert_equal({key_one: 1, key_2: 2}, new_hash)
   end
 
-  def test_it_replaces_the_key_in_memory
+  def test_it_renames_the_key_in_memory
     hash = {key_1: 1, key_2: 2}
-    modified_hash = hash.replace_key!(:key_1, :key_one)
+    modified_hash = hash.rename_key!(:key_1, :key_one)
 
     assert_same(hash, modified_hash)
     assert_equal({key_one: 1, key_2: 2}, hash)
@@ -22,9 +22,9 @@ class TestReplaceKey < Minitest::Test
 
   def test_it_can_change_the_type
     hash = {key_1: 1, key_2: 2}
-    assert_equal({"key_one" => 1, key_2: 2}, hash.replace_key(:key_1, "key_one"))
+    assert_equal({"key_one" => 1, key_2: 2}, hash.rename_key(:key_1, "key_one"))
 
-    hash.replace_key!(:key_1, "key_one")
+    hash.rename_key!(:key_1, "key_one")
     assert_equal({"key_one" => 1, key_2: 2}, hash)
   end
 end

--- a/test/core/hash/test_replace_key.rb
+++ b/test/core/hash/test_replace_key.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestReplaceKey < Minitest::Test
+  def test_it_replaces_the_key
+    hash = {key_1: 1, key_2: 2}
+    new_hash = hash.replace_key(:key_1, :key_one)
+
+    refute_same(hash, new_hash)
+    assert_equal({key_1: 1, key_2: 2}, hash)
+    assert_equal({key_one: 1, key_2: 2}, new_hash)
+  end
+
+  def test_it_replaces_the_key_in_memory
+    hash = {key_1: 1, key_2: 2}
+    modified_hash = hash.replace_key!(:key_1, :key_one)
+
+    assert_same(hash, modified_hash)
+    assert_equal({key_one: 1, key_2: 2}, hash)
+  end
+
+  def test_it_can_change_the_type
+    hash = {key_1: 1, key_2: 2}
+    assert_equal({"key_one" => 1, key_2: 2}, hash.replace_key(:key_1, "key_one"))
+
+    hash.replace_key!(:key_1, "key_one")
+    assert_equal({"key_one" => 1, key_2: 2}, hash)
+  end
+end

--- a/test/core/hash/test_replace_key.rb
+++ b/test/core/hash/test_replace_key.rb
@@ -22,9 +22,9 @@ class TestReplaceKey < Minitest::Test
 
   def test_it_can_change_the_type
     hash = {key_1: 1, key_2: 2}
-    assert_equal({"key_one" => 1, key_2: 2}, hash.rename_key(:key_1, "key_one"))
+    assert_equal({"key_one" => 1, :key_2 => 2}, hash.rename_key(:key_1, "key_one"))
 
     hash.rename_key!(:key_1, "key_one")
-    assert_equal({"key_one" => 1, key_2: 2}, hash)
+    assert_equal({"key_one" => 1, :key_2 => 2}, hash)
   end
 end

--- a/test/core/hash/test_replace_key_unordered.rb
+++ b/test/core/hash/test_replace_key_unordered.rb
@@ -3,9 +3,9 @@
 require "test_helper"
 
 class TestReplaceKeyUnordered < Minitest::Test
-  def test_it_replaces_the_key
+  def test_it_renames_the_key
     hash = {key_1: 1, key_2: 2}
-    new_hash = hash.replace_key_unordered(:key_1, :key_one)
+    new_hash = hash.rename_key_unordered(:key_1, :key_one)
 
     refute_same(hash, new_hash)
     assert_equal({key_1: 1, key_2: 2}, hash)
@@ -15,9 +15,9 @@ class TestReplaceKeyUnordered < Minitest::Test
     assert_equal([2, 1], new_hash.values)
   end
 
-  def test_it_replaces_the_key_in_memory
+  def test_it_renames_the_key_in_memory
     hash = {key_1: 1, key_2: 2}
-    modified_hash = hash.replace_key_unordered!(:key_1, :key_one)
+    modified_hash = hash.rename_key_unordered!(:key_1, :key_one)
 
     assert_same(hash, modified_hash)
 
@@ -28,9 +28,9 @@ class TestReplaceKeyUnordered < Minitest::Test
 
   def test_it_can_change_the_type
     hash = {key_1: 1, key_2: 2}
-    assert_equal({key_2: 2, "key_one" => 1}, hash.replace_key_unordered(:key_1, "key_one"))
+    assert_equal({key_2: 2, "key_one" => 1}, hash.rename_key_unordered(:key_1, "key_one"))
 
-    hash.replace_key_unordered!(:key_1, "key_one")
+    hash.rename_key_unordered!(:key_1, "key_one")
     assert_equal({key_2: 2, "key_one" => 1}, hash)
   end
 end

--- a/test/core/hash/test_replace_key_unordered.rb
+++ b/test/core/hash/test_replace_key_unordered.rb
@@ -28,9 +28,9 @@ class TestReplaceKeyUnordered < Minitest::Test
 
   def test_it_can_change_the_type
     hash = {key_1: 1, key_2: 2}
-    assert_equal({key_2: 2, "key_one" => 1}, hash.rename_key_unordered(:key_1, "key_one"))
+    assert_equal({:key_2 => 2, "key_one" => 1}, hash.rename_key_unordered(:key_1, "key_one"))
 
     hash.rename_key_unordered!(:key_1, "key_one")
-    assert_equal({key_2: 2, "key_one" => 1}, hash)
+    assert_equal({:key_2 => 2, "key_one" => 1}, hash)
   end
 end

--- a/test/core/hash/test_replace_key_unordered.rb
+++ b/test/core/hash/test_replace_key_unordered.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestReplaceKeyUnordered < Minitest::Test
+  def test_it_replaces_the_key
+    hash = {key_1: 1, key_2: 2}
+    new_hash = hash.replace_key_unordered(:key_1, :key_one)
+
+    refute_same(hash, new_hash)
+    assert_equal({key_1: 1, key_2: 2}, hash)
+
+    # Order is not preserved
+    assert_equal([:key_2, :key_one], new_hash.keys)
+    assert_equal([2, 1], new_hash.values)
+  end
+
+  def test_it_replaces_the_key_in_memory
+    hash = {key_1: 1, key_2: 2}
+    modified_hash = hash.replace_key_unordered!(:key_1, :key_one)
+
+    assert_same(hash, modified_hash)
+
+    # Order is not preserved
+    assert_equal([:key_2, :key_one], hash.keys)
+    assert_equal([2, 1], hash.values)
+  end
+
+  def test_it_can_change_the_type
+    hash = {key_1: 1, key_2: 2}
+    assert_equal({key_2: 2, "key_one" => 1}, hash.replace_key_unordered(:key_1, "key_one"))
+
+    hash.replace_key_unordered!(:key_1, "key_one")
+    assert_equal({key_2: 2, "key_one" => 1}, hash)
+  end
+end

--- a/test/core/hash/test_replace_keys.rb
+++ b/test/core/hash/test_replace_keys.rb
@@ -3,9 +3,9 @@
 require "test_helper"
 
 class TestReplaceKeys < Minitest::Test
-  def test_it_replaces_the_keys
+  def test_it_renames_the_keys
     hash = {key_1: 1, key_2: 2}
-    new_hash = hash.replace_keys(key_1: :key_one, key_2: :key_two)
+    new_hash = hash.rename_keys(key_1: :key_one, key_2: :key_two)
 
     refute_same(hash, new_hash)
     assert_equal({key_1: 1, key_2: 2}, hash)
@@ -15,9 +15,9 @@ class TestReplaceKeys < Minitest::Test
     assert_equal([1, 2], new_hash.values)
   end
 
-  def test_it_replaces_the_key_in_memory
+  def test_it_renames_the_key_in_memory
     hash = {key_1: 1, key_2: 2}
-    modified_hash = hash.replace_keys!(key_1: :key_one, key_2: :key_two)
+    modified_hash = hash.rename_keys!(key_1: :key_one, key_2: :key_two)
 
     assert_same(hash, modified_hash)
 
@@ -28,9 +28,9 @@ class TestReplaceKeys < Minitest::Test
 
   def test_it_can_change_the_type
     hash = {key_1: 1, key_2: 2}
-    assert_equal({"key_one" => 1, "key_two" => 2}, hash.replace_keys(key_1: "key_one", key_2: "key_two"))
+    assert_equal({"key_one" => 1, "key_two" => 2}, hash.rename_keys(key_1: "key_one", key_2: "key_two"))
 
-    hash.replace_keys!(key_1: "key_one", key_2: "key_two")
+    hash.rename_keys!(key_1: "key_one", key_2: "key_two")
     assert_equal({"key_one" => 1, "key_two" => 2}, hash)
   end
 end

--- a/test/core/hash/test_replace_keys.rb
+++ b/test/core/hash/test_replace_keys.rb
@@ -20,11 +20,12 @@ class TestReplaceKeys < Minitest::Test
     assert_equal({key_one: 1, key_two: 2}, hash)
   end
 
-  # def test_it_can_change_the_type
-  #   hash = {key_1: 1, key_2: 2}
-  #   assert_equal({"key_one" => 1, key_2: 2}, hash.replace_key(:key_1, "key_one"))
+  def test_it_replaces_keys_in_order
+    hash = {a: 1, b: 2, c: 3}
+    new_hash = hash.replace_keys(a: :b, b: :c)
 
-  #   hash.replace_key!(:key_1, "key_one")
-  #   assert_equal({"key_one" => 1, key_2: 2}, hash)
-  # end
+    # Order matters {b: 1, c:2}
+    assert_equal([:b, :c], new_hash.keys)
+    assert_equal([1, 3], new_hash.values)
+  end
 end

--- a/test/core/hash/test_replace_keys.rb
+++ b/test/core/hash/test_replace_keys.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestReplaceKeys < Minitest::Test
+  def test_it_replaces_the_keys
+    hash = {key_1: 1, key_2: 2}
+    new_hash = hash.replace_keys(key_1: :key_one, key_2: :key_two)
+
+    refute_same(hash, new_hash)
+    assert_equal({key_1: 1, key_2: 2}, hash)
+    assert_equal({key_one: 1, key_two: 2}, new_hash)
+  end
+
+  def test_it_replaces_the_key_in_memory
+    hash = {key_1: 1, key_2: 2}
+    modified_hash = hash.replace_keys!(key_1: :key_one, key_2: :key_two)
+
+    assert_same(hash, modified_hash)
+    assert_equal({key_one: 1, key_two: 2}, hash)
+  end
+
+  # def test_it_can_change_the_type
+  #   hash = {key_1: 1, key_2: 2}
+  #   assert_equal({"key_one" => 1, key_2: 2}, hash.replace_key(:key_1, "key_one"))
+
+  #   hash.replace_key!(:key_1, "key_one")
+  #   assert_equal({"key_one" => 1, key_2: 2}, hash)
+  # end
+end

--- a/test/core/hash/test_replace_keys.rb
+++ b/test/core/hash/test_replace_keys.rb
@@ -9,7 +9,10 @@ class TestReplaceKeys < Minitest::Test
 
     refute_same(hash, new_hash)
     assert_equal({key_1: 1, key_2: 2}, hash)
-    assert_equal({key_one: 1, key_two: 2}, new_hash)
+
+    # Order matters!
+    assert_equal([:key_one, :key_two], new_hash.keys)
+    assert_equal([1, 2], new_hash.values)
   end
 
   def test_it_replaces_the_key_in_memory
@@ -17,15 +20,17 @@ class TestReplaceKeys < Minitest::Test
     modified_hash = hash.replace_keys!(key_1: :key_one, key_2: :key_two)
 
     assert_same(hash, modified_hash)
-    assert_equal({key_one: 1, key_two: 2}, hash)
+
+    # Order matters!
+    assert_equal([:key_one, :key_two], hash.keys)
+    assert_equal([1, 2], hash.values)
   end
 
-  def test_it_replaces_keys_in_order
-    hash = {a: 1, b: 2, c: 3}
-    new_hash = hash.replace_keys(a: :b, b: :c)
+  def test_it_can_change_the_type
+    hash = {key_1: 1, key_2: 2}
+    assert_equal({"key_one" => 1, "key_two" => 2}, hash.replace_keys(key_1: "key_one", key_2: "key_two"))
 
-    # Order matters {b: 1, c:2}
-    assert_equal([:b, :c], new_hash.keys)
-    assert_equal([1, 3], new_hash.values)
+    hash.replace_keys!(key_1: "key_one", key_2: "key_two")
+    assert_equal({"key_one" => 1, "key_two" => 2}, hash)
   end
 end


### PR DESCRIPTION
Closes #20 

The original design approached this feature from the perspective of "I need to replace this one key in this Hash". But I realized that the perspective needed changed and I needed to look at this as "I want to rename this key in this Hash". 

After much benchmarking and testing, I landed on two versions based on ordering and speed. 