### PR TITLE
feat - Add `#in_quotes`/`#with_quotes` to more core classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 -->
 
+## [Unreleased]
+
+### Added
+
+- Created `Everythingrb::InspectQuotable` and `Everythingrb::StringQuotable` modules for consistent quote functionality
+- Extended quotable functionality to many more Ruby core classes:
+  - `TrueClass` and `FalseClass` (boolean values)
+  - `NilClass`
+  - `Numeric`
+  - `Range`
+  - `Regexp`
+  - `Time`, `Date`, and `DateTime`
+  - `Data` and `Struct` classes
+
+### Changed
+
+- Refactored existing quotable implementations to use the new modules
+- Standardized method order to prefer `in_quotes` as the primary method with `with_quotes` as an alias
+
+### Removed
+
 ## [0.6.1] - 12025-04-26
 
 ### Changed

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle exec rake test

--- a/bin/test
+++ b/bin/test
@@ -4,3 +4,4 @@ IFS=$'\n\t'
 set -vx
 
 bundle exec rake test
+bundle exec yard stats --list-undoc

--- a/lib/everythingrb/all.rb
+++ b/lib/everythingrb/all.rb
@@ -1,11 +1,18 @@
 # frozen_string_literal: true
 
 require_relative "array"
+require_relative "boolean"
 require_relative "data"
+require_relative "date"
 require_relative "enumerable"
 require_relative "hash"
 require_relative "module"
+require_relative "nil"
+require_relative "numeric"
 require_relative "ostruct"
+require_relative "range"
+require_relative "regexp"
 require_relative "string"
 require_relative "struct"
 require_relative "symbol"
+require_relative "time"

--- a/lib/everythingrb/array.rb
+++ b/lib/everythingrb/array.rb
@@ -16,6 +16,8 @@
 #   [{name: "Alice"}, {name: "Bob"}].key_map(:name)  # => ["Alice", "Bob"]
 #
 class Array
+  include Everythingrb::InspectQuotable
+
   #
   # Combines filter_map and join operations
   #

--- a/lib/everythingrb/boolean.rb
+++ b/lib/everythingrb/boolean.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+#
+# Extensions to Ruby's core TrueClass
+#
+# Provides:
+# - #in_quotes, #with_quotes: Wrap boolean values in quotes
+#
+# @example
+#   require "everythingrb/boolean"
+#
+#   true.in_quotes   # => "\"true\""
+#   false.in_quotes  # => "\"false\""
+#
+class TrueClass
+  include Everythingrb::InspectQuotable
+end
+
+#
+# Extensions to Ruby's core FalseClass
+#
+# Provides:
+# - #in_quotes, #with_quotes: Wrap boolean values in quotes
+#
+# @example
+#   require "everythingrb/boolean"
+#
+#   true.in_quotes   # => "\"true\""
+#   false.in_quotes  # => "\"false\""
+#
+class FalseClass
+  include Everythingrb::InspectQuotable
+end

--- a/lib/everythingrb/data.rb
+++ b/lib/everythingrb/data.rb
@@ -5,8 +5,11 @@
 #
 # Provides:
 # - #to_deep_h: Recursively convert to hash with all nested objects
+# - #in_quotes, #with_quotes: Wrap object in quotes
 #
 class Data
+  include Everythingrb::InspectQuotable
+
   #
   # Recursively converts the Data object and all nested objects to hashes
   #

--- a/lib/everythingrb/date.rb
+++ b/lib/everythingrb/date.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+#
+# Extensions to Ruby's core Date class
+#
+# Provides:
+# - #in_quotes, #with_quotes: Wrap date representations in quotes
+#
+# @example
+#   require "everythingrb/date"
+#
+#   Date.today.in_quotes
+#
+class Date
+  include Everythingrb::StringQuotable
+end
+
+#
+# Extensions to Ruby's core DateTime class
+#
+# Provides:
+# - #in_quotes, #with_quotes: Wrap time representations in quotes
+#
+# @example
+#   require "everythingrb/date"
+#
+#   DateTime.now.in_quotes
+#
+class DateTime < Date
+  include Everythingrb::StringQuotable
+end

--- a/lib/everythingrb/extensions.rb
+++ b/lib/everythingrb/extensions.rb
@@ -1,1 +1,3 @@
-Dir[File.expand_path("extensions/**/*.rb", __dir__)].each { |path| require path }
+# frozen_string_literal: true
+
+Dir[File.expand_path("./extensions/**/*.rb", __dir__)].each { |path| require path }

--- a/lib/everythingrb/extensions.rb
+++ b/lib/everythingrb/extensions.rb
@@ -1,0 +1,1 @@
+Dir[File.expand_path("extensions/**/*.rb", __dir__)].each { |path| require path }

--- a/lib/everythingrb/extensions/quotable.rb
+++ b/lib/everythingrb/extensions/quotable.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 #
-# Makes objects quotable with double quotes around their string representation
+# Extensions for making objects quotable with double quotes
 #
-# The Quotable module adds the ability to quote any object's string
-# representation by wrapping it in double quotes. This is useful for
+# These modules add the ability to quote objects by wrapping
+# their string representations in double quotes. This is useful for
 # generating error messages, debug output, or formatted logs where
 # you want to clearly distinguish between different value types.
 #
@@ -25,18 +25,53 @@
 #   # => "Expected \"42\" but got \"nil\""
 #
 module Everythingrb
-  module Quotable
+  #
+  # Adds quotable functionality using inspect representation
+  #
+  # Provides methods for wrapping an object's inspection
+  # representation in double quotes for debugging and error messages.
+  #
+  # @example
+  #   [1, 2, 3].in_quotes  # => "\"[1, 2, 3]\""
+  #
+  module InspectQuotable
     #
-    # Returns the object's string representation wrapped in double quotes
+    # Returns the object's inspection representation wrapped in double quotes
     #
     # @return [String] The object's inspect representation surrounded by double quotes
     #
     # @example
-    #   1.in_quotes      # => "\"1\""
-    #   nil.in_quotes    # => "\"nil\""
+    #   [1, 2, 3].in_quotes      # => "\"[1, 2, 3]\""
+    #   {a: 1}.in_quotes         # => "\"{:a=>1}\""
     #
     def in_quotes
       %("#{inspect}")
+    end
+
+    alias_method :with_quotes, :in_quotes
+  end
+
+  #
+  # Adds quotable functionality using to_s representation
+  #
+  # Provides methods for wrapping an object's string
+  # representation in double quotes for cleaner output.
+  #
+  # @example
+  #   Time.now.in_quotes  # => "\"2025-05-03 12:34:56 -0400\""
+  #
+  module StringQuotable
+    #
+    # Returns the object's string representation wrapped in double quotes
+    #
+    # @return [String] The object's to_s representation surrounded by double quotes
+    #
+    # @example
+    #   Date.today.in_quotes      # => "\"2025-05-03\""
+    #   Time.now.in_quotes        # => "\"2025-05-03 12:34:56 -0400\""
+    #
+    def in_quotes
+      %("#{self}")
     end
 
     alias_method :with_quotes, :in_quotes

--- a/lib/everythingrb/extensions/quotable.rb
+++ b/lib/everythingrb/extensions/quotable.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+#
+# Makes objects quotable with double quotes around their string representation
+#
+# The Quotable module adds the ability to quote any object's string
+# representation by wrapping it in double quotes. This is useful for
+# generating error messages, debug output, or formatted logs where
+# you want to clearly distinguish between different value types.
+#
+# @example Basic usage with different types
+#   1.in_quotes                   # => "\"1\""
+#   nil.in_quotes                 # => "\"nil\""
+#   "hello".in_quotes             # => "\"\\\"hello\\\"\""
+#   [1, 2, 3].in_quotes           # => "\"[1, 2, 3]\""
+#
+# @example Using with collections
+#   values = [1, nil, "hello"]
+#   values.map(&:in_quotes)       # => ["\"1\"", "\"nil\"", "\"\\\"hello\\\"\""]
+#
+# @example Error messages
+#   expected = 42
+#   actual = nil
+#   raise "Expected #{expected.in_quotes} but got #{actual.in_quotes}"
+#   # => "Expected \"42\" but got \"nil\""
+#
+module Everythingrb
+  module Quotable
+    #
+    # Returns the object's string representation wrapped in double quotes
+    #
+    # @return [String] The object's inspect representation surrounded by double quotes
+    #
+    # @example
+    #   1.in_quotes      # => "\"1\""
+    #   nil.in_quotes    # => "\"nil\""
+    #
+    def in_quotes
+      %("#{inspect}")
+    end
+
+    alias_method :with_quotes, :in_quotes
+  end
+end

--- a/lib/everythingrb/hash.rb
+++ b/lib/everythingrb/hash.rb
@@ -19,6 +19,8 @@
 #   config.server.port  # => 443
 #
 class Hash
+  include Everythingrb::InspectQuotable
+
   #
   # A minimal empty struct for Ruby 3.2+ compatibility
   #

--- a/lib/everythingrb/nil.rb
+++ b/lib/everythingrb/nil.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+#
+# Extensions to Ruby's NilClass
+#
+# Provides:
+# - #in_quotes, #with_quotes: Wrap nil's string representation in quotes
+#
+# @example
+#   require "everythingrb/extensions/nil_class"
+#   nil.in_quotes  # => "\"nil\""
+#
+class NilClass
+  include Everythingrb::InspectQuotable
+end

--- a/lib/everythingrb/numeric.rb
+++ b/lib/everythingrb/numeric.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+#
+# Extensions to Ruby's core Numeric class and subclasses
+#
+# Provides:
+# - #in_quotes, #with_quotes: Wrap numeric values in quotes
+#
+# @example
+#   require "everythingrb/numeric"
+#
+#   42.in_quotes      # => "\"42\""
+#   3.14.in_quotes    # => "\"3.14\""
+#   (1+2i).in_quotes  # => "\"1+2i\""
+#
+class Numeric
+  include Everythingrb::InspectQuotable
+end

--- a/lib/everythingrb/ostruct.rb
+++ b/lib/everythingrb/ostruct.rb
@@ -8,6 +8,7 @@
 # - #join_map: Combine filter_map and join operations
 # - #blank?, #present?: ActiveSupport integrations when available
 # - #to_deep_h: Recursively convert to hash with all nested objects
+# - #in_quotes, #with_quotes: Wrap struct in quotes
 #
 # @example
 #   require "everythingrb/ostruct"
@@ -16,6 +17,8 @@
 #   person.map { |k, v| "#{k}: #{v}" }  # => ["name: Alice", "age: 30"]
 #
 class OpenStruct
+  include Everythingrb::InspectQuotable
+
   # ActiveSupport integrations
   if defined?(ActiveSupport)
     #

--- a/lib/everythingrb/prelude.rb
+++ b/lib/everythingrb/prelude.rb
@@ -27,4 +27,5 @@ require "json"
 module Everythingrb
 end
 
+require_relative "extensions"
 require_relative "version"

--- a/lib/everythingrb/range.rb
+++ b/lib/everythingrb/range.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+#
+# Extensions to Ruby's core Range class
+#
+# Provides:
+# - #in_quotes, #with_quotes: Wrap range representations in quotes
+#
+# @example
+#   require "everythingrb/range"
+#
+#   (1..5).in_quotes     # => "\"1..5\""
+#   ('a'..'z').in_quotes # => "\"a..z\""
+#
+class Range
+  include Everythingrb::InspectQuotable
+end

--- a/lib/everythingrb/regexp.rb
+++ b/lib/everythingrb/regexp.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+#
+# Extensions to Ruby's core Regexp class
+#
+# Provides:
+# - #in_quotes, #with_quotes: Wrap regular expression representations in quotes
+#
+# @example
+#   require "everythingrb/regexp"
+#
+#   /\d+/.in_quotes  # => "\"/\\d+/\""
+#
+class Regexp
+  include Everythingrb::InspectQuotable
+end

--- a/lib/everythingrb/string.rb
+++ b/lib/everythingrb/string.rb
@@ -16,6 +16,8 @@
 #   "Hello".with_quotes  # => "\"Hello\""
 #
 class String
+  include Everythingrb::StringQuotable
+
   #
   # Converts JSON string to Hash, returning nil if it failed
   #
@@ -111,19 +113,4 @@ class String
   def to_struct
     to_h&.to_struct
   end
-
-  #
-  # Returns self wrapped in double quotes
-  #
-  # @return [String] The string with surrounding double quotes
-  #
-  # @example
-  #   "Hello World".with_quotes           # => "\"Hello World\""
-  #   "Quote \"me\"".with_quotes          # => "\"Quote \\\"me\\\"\""
-  #
-  def with_quotes
-    %("#{self}")
-  end
-
-  alias_method :in_quotes, :with_quotes
 end

--- a/lib/everythingrb/struct.rb
+++ b/lib/everythingrb/struct.rb
@@ -5,6 +5,7 @@
 #
 # Provides:
 # - #to_deep_h: Recursively convert to hash with all nested objects
+# - #in_quotes, #with_quotes: Wrap struct in quotes
 #
 # @example
 #   require "everythingrb/struct"
@@ -14,6 +15,8 @@
 #   person.to_deep_h  # => {name: "Alice", profile: {roles: ["admin"]}}
 #
 class Struct
+  include Everythingrb::InspectQuotable
+
   #
   # Recursively converts the Struct and all nested objects to hashes
   #

--- a/lib/everythingrb/symbol.rb
+++ b/lib/everythingrb/symbol.rb
@@ -18,12 +18,12 @@ class Symbol
   # @return [Symbol] The symbol with surrounding double quotes
   #
   # @example
-  #   :hello_world.with_quotes  # => :"\"hello_world\""
+  #   :hello_world.in_quotes  # => :"\"hello_world\""
   #   :hello_world.in_quotes    # => :"\"hello_world\""
   #
-  def with_quotes
+  def in_quotes
     :"\"#{self}\""
   end
 
-  alias_method :in_quotes, :with_quotes
+  alias_method :with_quotes, :in_quotes
 end

--- a/lib/everythingrb/time.rb
+++ b/lib/everythingrb/time.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+#
+# Extensions to Ruby's core Time class
+#
+# Provides:
+# - #in_quotes, #with_quotes: Wrap time representations in quotes
+#
+# @example
+#   require "everythingrb/time"
+#
+#   Time.new(2025, 5, 3).in_quotes
+#
+class Time
+  include Everythingrb::StringQuotable
+end

--- a/test/extensions/test_quotable.rb
+++ b/test/extensions/test_quotable.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestInspectQuotable < Minitest::Test
+  def test_it_quotes_array
+    assert_equal("\"[1, 2, 3]\"", [1, 2, 3].in_quotes)
+    assert_equal("\"[1, 2, 3]\"", [1, 2, 3].with_quotes)
+  end
+
+  def test_it_quotes_hash
+    assert_equal("\"{:a=>1}\"", {a: 1}.in_quotes)
+  end
+
+  def test_it_quotes_nil
+    assert_equal("\"nil\"", nil.in_quotes)
+  end
+
+  def test_it_quotes_boolean
+    assert_equal("\"true\"", true.in_quotes)
+    assert_equal("\"false\"", false.in_quotes)
+  end
+
+  def test_it_quotes_regexp
+    assert_equal("\"/test/i\"", /test/i.in_quotes)
+  end
+
+  def test_it_quotes_numeric
+    assert_equal("\"42\"", 42.in_quotes)
+    assert_equal("\"3.14\"", 3.14.in_quotes)
+  end
+
+  def test_it_quotes_range
+    assert_equal("\"1..5\"", (1..5).in_quotes)
+  end
+end
+
+class TestStringQuotable < Minitest::Test
+  def test_it_quotes_time
+    time = Time.new(2025, 5, 3, 12, 34, 56, "+00:00")
+    expected = "\"2025-05-03 12:34:56 +0000\""
+    assert_equal(expected, time.in_quotes)
+  end
+
+  def test_it_quotes_date
+    date = Date.new(2025, 5, 3)
+    assert_equal("\"2025-05-03\"", date.in_quotes)
+  end
+
+  def test_it_quotes_datetime
+    datetime = DateTime.new(2025, 5, 3, 12, 34, 56, "+00:00")
+    expected = "\"2025-05-03T12:34:56+00:00\""
+    assert_equal(expected, datetime.in_quotes)
+  end
+end

--- a/test/extensions/test_quotable.rb
+++ b/test/extensions/test_quotable.rb
@@ -14,7 +14,13 @@ class TestInspectQuotable < Minitest::Test
   end
 
   def test_it_quotes_hash
-    assert_equal("\"{:a=>1}\"", {a: 1}.in_quotes)
+    quoted_hash = {a: 1}.in_quotes
+
+    if RUBY_VERSION >= "3.4.0"
+      assert_equal("\"{a: 1}\"", quoted_hash)
+    else
+      assert_equal("\"{:a=>1}\"", quoted_hash)
+    end
   end
 
   def test_it_quotes_nil

--- a/test/extensions/test_quotable.rb
+++ b/test/extensions/test_quotable.rb
@@ -8,6 +8,11 @@ class TestInspectQuotable < Minitest::Test
     assert_equal("\"[1, 2, 3]\"", [1, 2, 3].with_quotes)
   end
 
+  def test_it_quotes_boolean
+    assert_equal("\"true\"", true.in_quotes)
+    assert_equal("\"false\"", false.in_quotes)
+  end
+
   def test_it_quotes_hash
     assert_equal("\"{:a=>1}\"", {a: 1}.in_quotes)
   end
@@ -16,22 +21,23 @@ class TestInspectQuotable < Minitest::Test
     assert_equal("\"nil\"", nil.in_quotes)
   end
 
-  def test_it_quotes_boolean
-    assert_equal("\"true\"", true.in_quotes)
-    assert_equal("\"false\"", false.in_quotes)
-  end
-
-  def test_it_quotes_regexp
-    assert_equal("\"/test/i\"", /test/i.in_quotes)
-  end
-
   def test_it_quotes_numeric
     assert_equal("\"42\"", 42.in_quotes)
     assert_equal("\"3.14\"", 3.14.in_quotes)
   end
 
+  def test_it_quotes_structs
+    assert_equal("\"#<struct foo=\"bar\">\"", Struct.new(:foo).new("bar").in_quotes)
+    assert_equal("\"#<OpenStruct foo=\"bar\">\"", OpenStruct.new(foo: "bar").in_quotes)
+    assert_equal("\"#<data foo=\"bar\">\"", Data.define(:foo).new(foo: "bar").in_quotes)
+  end
+
   def test_it_quotes_range
     assert_equal("\"1..5\"", (1..5).in_quotes)
+  end
+
+  def test_it_quotes_regexp
+    assert_equal("\"/test/i\"", /test/i.in_quotes)
   end
 end
 


### PR DESCRIPTION
Closes #39 

### Added
- Created `Everythingrb::InspectQuotable` and `Everythingrb::StringQuotable` modules for consistent quote functionality
- Extended quotable functionality to many more Ruby core classes:
  - `TrueClass` and `FalseClass` (boolean values)
  - `NilClass`
  - `Numeric` and subclasses
  - `Range`
  - `Regexp`
  - `Time`, `Date`, and `DateTime`
  - `Data` and `Struct` classes

### Changed
- Refactored existing quotable implementations to use the new modules
- Standardized method order to prefer `in_quotes` as the primary method with `with_quotes` as an alias
- Improved organization with a new extensions directory pattern

### Removed
- Direct implementation of quotable methods in `String` class