### PR TITLE
feat -  Add `Hash#select_values` and `Hash#reject_values` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Regexp`
   - `Time`, `Date`, and `DateTime`
   - `Data` and `Struct` classes
+- Added new Hash methods for filtering based on values only:
+  - `Hash#select_values` - Returns a new hash with entries where the block returns true for the value
+  - `Hash#select_values!` - Same as `select_values` but modifies the hash in place
+  - `Hash#reject_values` - Returns a new hash with entries where the block returns false for the value
+  - `Hash#reject_values!` - Same as `reject_values` but modifies the hash in place
+  - Added `filter_values` and `filter_values!` as aliases for `select_values` and `select_values!` respectively
 
 ### Changed
 

--- a/lib/everythingrb/hash.rb
+++ b/lib/everythingrb/hash.rb
@@ -665,4 +665,100 @@ class Hash
     self[new_key] = delete(old_key)
     self
   end
+
+  #
+  # Selects hash entries based only on their values
+  #
+  # @yield [value] Block that determines whether to include the entry
+  # @yieldparam value [Object] The current value
+  # @yieldreturn [Boolean] Whether to include this entry
+  #
+  # @return [Hash] A new hash including only entries where the block returned truthy
+  # @return [Enumerator] If no block is given
+  #
+  # @example Filter to include only present values (with ActiveSupport)
+  #   {name: "Alice", bio: nil, role: ""}.select_values(&:present?)
+  #   # => {name: "Alice"}
+  #
+  # @example Filter using more complex logic
+  #   {id: 1, count: 0, items: [1, 2, 3]}.select_values { |v| v.is_a?(Array) || v > 0 }
+  #   # => {id: 1, items: [1, 2, 3]}
+  #
+  def select_values(&block)
+    return to_enum(:select_values) if block.nil?
+
+    select { |_k, v| block.call(v) }
+  end
+
+  alias_method :filter_values, :select_values
+
+  #
+  # Selects hash entries based only on their values, modifying the hash in place
+  #
+  # @yield [value] Block that determines whether to keep the entry
+  # @yieldparam value [Object] The current value
+  # @yieldreturn [Boolean] Whether to keep this entry
+  #
+  # @return [self, nil] The modified hash, or nil if no changes were made
+  # @return [Enumerator] If no block is given
+  #
+  # @example Remove entries with empty values (with ActiveSupport)
+  #   hash = {name: "Alice", bio: nil, role: ""}
+  #   hash.select_values!(&:present?)
+  #   # => {name: "Alice"}
+  #   # hash is now {name: "Alice"}
+  #
+  def select_values!(&block)
+    return to_enum(:select_values!) if block.nil?
+
+    select! { |_k, v| block.call(v) }
+  end
+
+  alias_method :filter_values!, :select_values!
+
+  #
+  # Rejects hash entries based only on their values
+  #
+  # @yield [value] Block that determines whether to exclude the entry
+  # @yieldparam value [Object] The current value
+  # @yieldreturn [Boolean] Whether to exclude this entry
+  #
+  # @return [Hash] A new hash excluding entries where the block returned truthy
+  # @return [Enumerator] If no block is given
+  #
+  # @example Remove blank values (with ActiveSupport)
+  #   {name: "Alice", bio: nil, role: ""}.reject_values(&:blank?)
+  #   # => {name: "Alice"}
+  #
+  # @example Remove specific types of values
+  #   {id: 1, count: 0, items: [1, 2, 3]}.reject_values { |v| v.is_a?(Integer) && v == 0 }
+  #   # => {id: 1, items: [1, 2, 3]}
+  #
+  def reject_values(&block)
+    return to_enum(:reject_values) if block.nil?
+
+    reject { |_k, v| block.call(v) }
+  end
+
+  #
+  # Rejects hash entries based only on their values, modifying the hash in place
+  #
+  # @yield [value] Block that determines whether to remove the entry
+  # @yieldparam value [Object] The current value
+  # @yieldreturn [Boolean] Whether to remove this entry
+  #
+  # @return [self, nil] The modified hash, or nil if no changes were made
+  # @return [Enumerator] If no block is given
+  #
+  # @example Remove blank values in place (with ActiveSupport)
+  #   hash = {name: "Alice", bio: nil, role: ""}
+  #   hash.reject_values!(&:blank?)
+  #   # => {name: "Alice"}
+  #   # hash is now {name: "Alice"}
+  #
+  def reject_values!(&block)
+    return to_enum(:reject_values!) if block.nil?
+
+    reject! { |_k, v| block.call(v) }
+  end
 end

--- a/test/hash/test_reject_values.rb
+++ b/test/hash/test_reject_values.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestHashRejectValues < Minitest::Test
+  def setup
+    @hash = {a: 1, b: 2, c: 3, d: 4}
+    @block = ->(v) { v % 2 == 0 }
+  end
+
+  def test_it_rejects_based_on_value
+    result = @hash.reject_values(&@block)
+
+    assert_equal({a: 1, c: 3}, result)
+  end
+
+  def test_it_rejects_based_on_value_in_memory
+    @hash.reject_values!(&@block)
+
+    assert_equal({a: 1, c: 3}, @hash)
+  end
+
+  def test_it_returns_enum
+    assert_kind_of(Enumerable, @hash.reject_values)
+  end
+
+  def test_it_returns_enum_for_bang
+    assert_kind_of(Enumerable, @hash.reject_values!)
+  end
+end

--- a/test/hash/test_select_values.rb
+++ b/test/hash/test_select_values.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestHashSelectValues < Minitest::Test
+  def setup
+    @hash = {a: 1, b: 2, c: 3, d: 4}
+    @block = ->(v) { v % 2 == 0 }
+  end
+
+  def test_it_selects_based_on_value
+    result = @hash.select_values(&@block)
+
+    assert_equal({b: 2, d: 4}, result)
+  end
+
+  def test_it_selects_based_on_value_in_memory
+    @hash.select_values!(&@block)
+
+    assert_equal({b: 2, d: 4}, @hash)
+  end
+
+  def test_it_filters_based_on_value
+    result = @hash.filter_values(&@block)
+
+    assert_equal({b: 2, d: 4}, result)
+  end
+
+  def test_it_filters_based_on_value_in_memory
+    @hash.filter_values!(&@block)
+
+    assert_equal({b: 2, d: 4}, @hash)
+  end
+
+  def test_it_returns_select_enum
+    assert_kind_of(Enumerable, @hash.select_values)
+  end
+
+  def test_it_returns_select_enum_for_bang
+    assert_kind_of(Enumerable, @hash.select_values!)
+  end
+end


### PR DESCRIPTION
Closes #40 

- Added new Hash methods for filtering based on values only:
  - `Hash#select_values` - Returns a new hash with entries where the block returns true for the value
  - `Hash#select_values!` - Same as `select_values` but modifies the hash in place
  - `Hash#reject_values` - Returns a new hash with entries where the block returns false for the value
  - `Hash#reject_values!` - Same as `reject_values` but modifies the hash in place
  - Added `filter_values` and `filter_values!` as aliases for `select_values` and `select_values!` respectively