### PR TITLE
fix(hash) - Fixed `Hash#rename_key_unordered` and `Hash#rename_key_unordered!` handling of non-existant keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 -->
 
+## [0.8.2] - 12025-05-25
+
+### Added
+
+### Changed
+
+- Fixed `Hash#rename_key_unordered` and `Hash#rename_key_unordered!` to not create new key-value pairs when the original key doesn't exist. Previously, these methods would incorrectly add the `new_key` to the hash even when `old_key` was missing.
+
+### Removed
+
 ## [0.8.1] - 12025-05-21
 
 ### Added
@@ -291,7 +301,8 @@ This change aligns our method signatures with Ruby's conventions and matches our
 
 - Added alias `each` to `each_pair` in OpenStruct for better enumerable compatibility
 
-[unreleased]: https://github.com/itsthedevman/everythingrb/compare/v0.8.1...HEAD
+[unreleased]: https://github.com/itsthedevman/everythingrb/compare/v0.8.2...HEAD
+[0.8.2]: https://github.com/itsthedevman/everythingrb/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/itsthedevman/everythingrb/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/itsthedevman/everythingrb/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/itsthedevman/everythingrb/compare/v0.6.1...v0.7.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    everythingrb (0.8.1)
+    everythingrb (0.8.2)
       json (~> 2.10)
       ostruct (~> 0.6)
 
@@ -30,7 +30,7 @@ GEM
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     date (3.4.1)
-    drb (2.2.1)
+    drb (2.2.3)
     erb (5.0.1)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
@@ -39,7 +39,7 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.12.0)
+    json (2.12.2)
     kramdown (2.5.1)
       rexml (>= 3.3.9)
     language_server-protocol (3.17.0.5)
@@ -72,7 +72,7 @@ GEM
     reline (0.6.1)
       io-console (~> 0.5)
     rexml (3.4.1)
-    rubocop (1.75.6)
+    rubocop (1.75.7)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)

--- a/lib/everythingrb/hash.rb
+++ b/lib/everythingrb/hash.rb
@@ -629,6 +629,10 @@ class Hash
     # But as the hash becomes larger, the performance improvements become diminished until they're roughly the same.
     # Neat!
     hash = except(old_key)
+
+    # Only modify the hash if the old key exists
+    return hash unless key?(old_key)
+
     hash[new_key] = self[old_key]
     hash
   end
@@ -650,6 +654,9 @@ class Hash
   #   # => {a: 1, c: 3, middle: 2}  # Order may differ
   #
   def rename_key_unordered!(old_key, new_key)
+    # Only modify the hash if the old key exists
+    return self unless key?(old_key)
+
     self[new_key] = delete(old_key)
     self
   end

--- a/lib/everythingrb/version.rb
+++ b/lib/everythingrb/version.rb
@@ -7,5 +7,5 @@
 #
 module Everythingrb
   # Current version of the everythingrb gem
-  VERSION = "0.8.1"
+  VERSION = "0.8.2"
 end

--- a/test/hash/test_replace_key.rb
+++ b/test/hash/test_replace_key.rb
@@ -27,4 +27,14 @@ class TestReplaceKey < Minitest::Test
     hash.rename_key!(:key_1, "key_one")
     assert_equal({"key_one" => 1, :key_2 => 2}, hash)
   end
+
+  def test_it_does_not_add_non_existent_key
+    hash = {baz: true}
+
+    result = hash.rename_key(:foo, :bar)
+    assert_equal({baz: true}, result)
+
+    hash.rename_key!(:foo, :bar)
+    assert_equal({baz: true}, hash)
+  end
 end

--- a/test/hash/test_replace_key_unordered.rb
+++ b/test/hash/test_replace_key_unordered.rb
@@ -33,4 +33,14 @@ class TestReplaceKeyUnordered < Minitest::Test
     hash.rename_key_unordered!(:key_1, "key_one")
     assert_equal({:key_2 => 2, "key_one" => 1}, hash)
   end
+
+  def test_it_does_not_add_non_existent_key
+    hash = {baz: true}
+
+    result = hash.rename_key_unordered(:foo, :bar)
+    assert_equal({baz: true}, result)
+
+    hash.rename_key_unordered!(:foo, :bar)
+    assert_equal({baz: true}, hash)
+  end
 end

--- a/test/hash/test_replace_keys.rb
+++ b/test/hash/test_replace_keys.rb
@@ -33,4 +33,14 @@ class TestReplaceKeys < Minitest::Test
     hash.rename_keys!(key_1: "key_one", key_2: "key_two")
     assert_equal({"key_one" => 1, "key_two" => 2}, hash)
   end
+
+  def test_it_does_not_add_non_existent_key
+    hash = {baz: true}
+
+    result = hash.rename_keys(foo: :bar)
+    assert_equal({baz: true}, result)
+
+    hash.rename_keys!(foo: :bar)
+    assert_equal({baz: true}, hash)
+  end
 end


### PR DESCRIPTION
Resolves #59 